### PR TITLE
Fix persist capability

### DIFF
--- a/persist.c
+++ b/persist.c
@@ -166,6 +166,12 @@ int persist_check(char *myname, int *authfd) {
          return -1;
       }
 
+      /* Make sure token file is owned by root:root */
+      if (fchownat(dirfd, tsname, 0, 0, 0) == -1) {
+        close(dirfd);
+        return -1;
+      }
+
       *authfd = fd;
 
       /* If we had to create the token file then there's no


### PR DESCRIPTION
  Ensures that the token files are owned by root:root as this is required
    for the 'nodeinfo.*' tests in persist_check().

  [User] foo:bar
  The problem is that when run by user 'foo', 'openat()' with O_CREAT
    will create the file with ownership:  root:bar
  This will cause persist_check() to fail during
    the: 'nodeinfo.st_git != 0' test and return -1.